### PR TITLE
Bug allow empty modellist declaration

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -1,3 +1,7 @@
+/* global angular:false */
+
+'use strict';
+
 var module = angular.module('modelFactory', []);
 
 // compression
@@ -229,21 +233,27 @@ module.factory('$modelFactory', function($http, $q, $log, $cacheFactory){
         function ModelCollection(value){
             var instance = this;
 
-            // wrap each obj
-            value.forEach(function(v, i){
-                // this should not happen but prevent blow up
-                if(v === null || v === undefined) return;
+            if(value){
+                // wrap each obj
+                value.forEach(function(v, i){
+                    // this should not happen but prevent blow up
+                    if(v === null || v === undefined) return;
 
-                // create an instance
-                var inst = v.constructor === Model ?
-                    v : new Model(v);
+                    // create an instance
+                    var inst = v.constructor === Model ?
+                        v : new Model(v);
 
-                // set a pointer to the array
-                inst.$$array = value;
+                    // set a pointer to the array
+                    inst.$$array = value;
 
-                // reset to new instance
-                value[i] = inst;
-            });
+                    // reset to new instance
+                    value[i] = inst;
+                });
+            }else{
+                // no list has been provided, thus create an empty array to
+                // allow for later push's
+                value = [];
+            }
 
             // override push to set an instance
             // of the list on the model so destroys will chain

--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -233,27 +233,23 @@ module.factory('$modelFactory', function($http, $q, $log, $cacheFactory){
         function ModelCollection(value){
             var instance = this;
 
-            if(value){
-                // wrap each obj
-                value.forEach(function(v, i){
-                    // this should not happen but prevent blow up
-                    if(v === null || v === undefined) return;
+            value = value || [];
 
-                    // create an instance
-                    var inst = v.constructor === Model ?
-                        v : new Model(v);
+            // wrap each obj
+            value.forEach(function(v, i){
+                // this should not happen but prevent blow up
+                if(v === null || v === undefined) return;
 
-                    // set a pointer to the array
-                    inst.$$array = value;
+                // create an instance
+                var inst = v.constructor === Model ?
+                    v : new Model(v);
 
-                    // reset to new instance
-                    value[i] = inst;
-                });
-            }else{
-                // no list has been provided, thus create an empty array to
-                // allow for later push's
-                value = [];
-            }
+                // set a pointer to the array
+                inst.$$array = value;
+
+                // reset to new instance
+                value[i] = inst;
+            });
 
             // override push to set an instance
             // of the list on the model so destroys will chain
@@ -288,9 +284,7 @@ module.factory('$modelFactory', function($http, $q, $log, $cacheFactory){
             var instance = this, old;
 
             // if the value is undefined, create a empty obj
-            if(value === undefined){
-                value = {};
-            }
+            value = value || {};
 
             // build the defaults but only on new instances
             forEach(options.defaults, function(v, k){

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -63,12 +63,30 @@ describe('A person model defined using modelFactory', function() {
             });
 
             // TODO this doesn't work right now...should it??
-            xit('should wrap newly added JavaScript objects', function(){
+            it('should wrap newly added JavaScript objects', function(){
                 modelList.push({
                     name: 'Tom'
                 });
 
                 expect(modelList[1] instanceof PersonModel).toBeTruthy();
+            });
+
+            it('should account for Array.push(obj1, obj2,...) API; all passed obj should be wrapped as models', function(){
+                var newList = new PersonModel.List();
+
+                // act
+                newList.push(
+                    {
+                        name: 'Juri'
+                    },
+                    {
+                        name: 'Austin'
+                    });
+
+                // assert
+                expect(newList.length).toEqual(2);
+                expect(newList[0] instanceof PersonModel).toBeTruthy();
+                expect(newList[1] instanceof PersonModel).toBeTruthy();
             });
 
             it('should allow to define an empty list', function() {
@@ -77,7 +95,7 @@ describe('A person model defined using modelFactory', function() {
                 expect(newEmptyList.length).toEqual(0);
             });
 
-            xit('should allow to add elements on a previously empty model list collection', function(){
+            it('should allow to add elements on a previously empty model list collection', function(){
                 var newList = new PersonModel.List();
 
                 newList.push({ name: 'Juri' });

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -62,8 +62,7 @@ describe('A person model defined using modelFactory', function() {
                 expect(modelList[0].$save).toBeDefined();
             });
 
-            // TODO this one fails...clarify whether it is intended behavior
-            xit('should allow to define an empty list', function() {
+            it('should allow to define an empty list', function() {
                 var newEmptyList = new PersonModel.List();
                 expect(newEmptyList).toBeDefined();
                 expect(newEmptyList.length).toEqual(0);

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -59,13 +59,30 @@ describe('A person model defined using modelFactory', function() {
             });
 
             it('should contain wrapped model objects', function() {
-                expect(modelList[0].$save).toBeDefined();
+                expect(modelList[0] instanceof PersonModel).toBeTruthy();
+            });
+
+            // TODO this doesn't work right now...should it??
+            xit('should wrap newly added JavaScript objects', function(){
+                modelList.push({
+                    name: 'Tom'
+                });
+
+                expect(modelList[1] instanceof PersonModel).toBeTruthy();
             });
 
             it('should allow to define an empty list', function() {
                 var newEmptyList = new PersonModel.List();
                 expect(newEmptyList).toBeDefined();
                 expect(newEmptyList.length).toEqual(0);
+            });
+
+            xit('should allow to add elements on a previously empty model list collection', function(){
+                var newList = new PersonModel.List();
+
+                newList.push({ name: 'Juri' });
+                expect(newList.length).toEqual(1);
+                expect(newList[0] instanceof PersonModel).toBeTruthy(); // wrapping should still work
             });
 
             it('should allow to add new models', function() {
@@ -449,7 +466,7 @@ describe('A person model defined using modelFactory', function() {
             PersonModel.queryChildren()
                 .then(function(result){
                     expect(result.length).toBe(1);
-                    expect(result[0].$save).toBeDefined(); // check whether it's a model
+                    expect(result[0] instanceof PersonModel).toBeTruthy(); // check whether it's a model
                 });
 
             $httpBackend.expectGET('/api/people/children').respond(200, [


### PR DESCRIPTION
Makes this test pass:

``` javascript
it('should allow to define an empty list', function() {
    var newEmptyList = new PersonModel.List();

    expect(newEmptyList).toBeDefined();
    expect(newEmptyList.length).toEqual(0);
});
```
