### PR TITLE
adds failing test demonstrating a bug with cloned models

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -399,7 +399,7 @@ module.provider('$modelFactory', function(){
 
                         var arr = instance.$$array;
                         if(arr){
-                            arr.splice(arr.indexOf(instance), 1);
+                            arr.splice(arr.indexOf(this), 1);
                         }
                     }, function(){
                         // rejected
@@ -436,6 +436,19 @@ module.provider('$modelFactory', function(){
                 instance.$extend = function(n){
                     extendDeep(instance, n);
                     return instance;
+                };
+
+
+                /**
+                 * Creates a copy by taking the raw data values and by
+                 * creating a new instance of the model.
+                 */
+                instance.$copy = function(){
+                  // get the raw data of the model
+                  var rawData = Model.$strip(this);
+
+                  // ..then wrap it into a new instance
+                  return new Model(rawData);
                 };
 
                 // Create a copy of the value last so we get all the goodies,

--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -445,10 +445,12 @@ module.provider('$modelFactory', function(){
                  */
                 instance.$copy = function(){
                   // get the raw data of the model
-                  var rawData = Model.$strip(this);
+                  // var rawData = Model.$strip(this);
+                  var rawData = angular.toJson(this);
+
 
                   // ..then wrap it into a new instance
-                  return new Model(rawData);
+                  return new Model(angular.fromJson(rawData));
                 };
 
                 // Create a copy of the value last so we get all the goodies,

--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -364,7 +364,7 @@ module.provider('$modelFactory', function(){
                  */
                 instance.$save = function(){
                     var promise = Model[instance[options.pk] ?
-                        'update' : 'post'](instance);
+                        'update' : 'post'](this);
 
                     instance.$pending = true;
 
@@ -391,7 +391,7 @@ module.provider('$modelFactory', function(){
                 instance.$destroy = function(){
                     // keep a local pointer since we strip before send
 
-                    var promise = Model.delete(instance);
+                    var promise = Model.delete(this);
                     instance.$pending = true;
 
                     promise.then(function(){

--- a/test/spec/modelFactory.spec.js
+++ b/test/spec/modelFactory.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/*
+  Specs that test the inner workings of the model-factory. Regression
+  tests can be placed in here.
+*/
+
+ddescribe('A person model defined using modelFactory', function() {
+    var PersonModel;
+    var $httpBackend;
+
+    beforeEach(angular.mock.module('modelFactory'));
+
+    beforeEach(function() {
+        angular.module('test-module', ['modelFactory'])
+            .factory('PersonModel', function($modelFactory) {
+                return $modelFactory('/api/people');
+            });
+    });
+
+    beforeEach(angular.mock.module('test-module'));
+
+    beforeEach(inject(function(_$httpBackend_, _PersonModel_) {
+        $httpBackend = _$httpBackend_;
+        PersonModel = _PersonModel_;
+    }));
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    // describe('when calling model.$strip', function(){
+    //     it('should remove all model-factory specific functions', function(){
+    //         var raw = {
+    //             id: 1,
+    //             name: 'Juri'
+    //         };
+
+    //         expect(new PersonModel(raw).$strip).toEqual(raw);
+    //     });
+    // });
+
+    describe('when copying a model object', function() {
+
+        it('calling $save on a new model should submit the copied values', function() {
+            var newModel = new PersonModel({
+                name: 'Juri'
+            });
+
+            var copied = angular.copy(newModel);
+            copied.name = 'Austin';
+
+            $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');
+
+            copied.$save();
+            $httpBackend.flush();
+        });
+
+        it('calling $save on it should submit the copied values', function() {
+            var newModel = new PersonModel({
+                name: 'Juri'
+            });
+
+            var copied = angular.copy(newModel);
+            copied.name = 'Austin';
+
+            $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');
+
+            copied.$save();
+            $httpBackend.flush();
+        });
+
+        it('calling $destroy on it should submit the copied values', function() {
+            var newModel = new PersonModel({
+                id: 1,
+                name: 'Juri'
+            });
+
+            var copied = angular.copy(newModel);
+            copied.id = 100;
+
+            $httpBackend.expectDELETE('/api/people/100').respond(200, '');
+
+            copied.$destroy();
+            $httpBackend.flush();
+        });
+
+    });
+
+});

--- a/test/spec/modelFactory.spec.js
+++ b/test/spec/modelFactory.spec.js
@@ -5,7 +5,7 @@
   tests can be placed in here.
 */
 
-ddescribe('A person model defined using modelFactory', function() {
+describe('A person model defined using modelFactory', function() {
     var PersonModel;
     var $httpBackend;
 
@@ -48,7 +48,7 @@ ddescribe('A person model defined using modelFactory', function() {
                 name: 'Juri'
             });
 
-            var copied = angular.copy(newModel);
+            var copied = newModel.$copy(); //angular.copy(newModel);
             copied.name = 'Austin';
 
             $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');
@@ -62,7 +62,7 @@ ddescribe('A person model defined using modelFactory', function() {
                 name: 'Juri'
             });
 
-            var copied = angular.copy(newModel);
+            var copied = newModel.$copy(); //angular.copy(newModel);
             copied.name = 'Austin';
 
             $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');
@@ -77,13 +77,40 @@ ddescribe('A person model defined using modelFactory', function() {
                 name: 'Juri'
             });
 
-            var copied = angular.copy(newModel);
+            var copied = newModel.$copy(); // angular.copy(newModel);
             copied.id = 100;
 
             $httpBackend.expectDELETE('/api/people/100').respond(200, '');
 
             copied.$destroy();
             $httpBackend.flush();
+        });
+
+        it('calling $destroy on a model list entry should not have any effect on the list', function(){
+
+            var modelList = new PersonModel.List([
+                {
+                    id: 1,
+                    name: 'Juri'
+                },
+                {
+                    id: 2,
+                    name: 'Austin'
+                },
+                {
+                    id: 3,
+                    name: 'Tim'
+                }
+            ]);
+
+            var copy = modelList[1].$copy(); // angular.copy(modelList[1]);
+
+            $httpBackend.expectDELETE('/api/people/2').respond(200,'');
+
+            copy.$destroy();
+            $httpBackend.flush();
+
+            expect(modelList.length).toEqual(3);
         });
 
     });

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -268,6 +268,22 @@ describe('A person model defined using modelFactory', function() {
                 expect(newModel.name).toEqual('Juri Strumpflohner');
             });
 
+            it('on a copied model it should sent back the copied model data', function(){
+                var newModel = new PersonModel({
+                    name: 'Juri'
+                });
+
+
+                var copied = angular.copy(newModel);
+                copied.name = 'Austin'; //change something in the clone
+
+                $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');
+
+
+                copied.$save();
+                $httpBackend.flush();
+            });
+
         });
 
         describe('when calling $revert', function() {

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -469,7 +469,7 @@ describe('A person model defined using modelFactory', function() {
                             },
 
                             // instance function
-                            '$copy': {
+                            '$serverCopy': {
                                 method: 'POST',
                                 url: 'copy'
                             }
@@ -527,7 +527,7 @@ describe('A person model defined using modelFactory', function() {
             $httpBackend.expectPOST('/api/people/copy').respond(200, '');
 
             // act
-            model.$copy();
+            model.$serverCopy();
             $httpBackend.flush();
         });
 


### PR DESCRIPTION
I added this test which is failing as of now.

``` javascript
it('on a copied model it should sent back the copied model data', function(){
    var newModel = new PersonModel({
        name: 'Juri'
    });

    var copied = angular.copy(newModel);
    copied.name = 'Austin'; //change something in the clone

    $httpBackend.expectPOST('/api/people', JSON.stringify(copied)).respond(200, '');


    copied.$save();
    $httpBackend.flush();
});
```

When executing this test I get

![image](https://cloud.githubusercontent.com/assets/542458/5259173/991038bc-79fc-11e4-8cfe-9feb5cfabec6.png)

**The scenario** is the following. Take the this simple master-detail editing UI:

![image](https://cloud.githubusercontent.com/assets/542458/5230577/7b9d025a-7728-11e4-8cca-c0f5f742a284.gif)

When clicking on an item to start editing I want to update the list entry **only after the user clicked the save button and everything has been stored successfully on the server**, rather than the auto-updating scenario due to the live binding.

As such, I create a copy of the model using `angular.copy(...)` which I'm currently editing, for then merging it back into the original one once `$save()` succeeded. When doing so, I notice that `.copy(...)` does not work properly, at least not when then invoking `$save()` on the copied model as it will always take the data from original one rather than the newly copied.

I suspect it has something to do with [this line](https://github.com/phxdatasec/model-factory/blob/master/src/modelFactory.js#L335) as the data is somehow gathered from some internal variable.

@amcdnl Any idea on this? Or how we could fix it?
