### PR TITLE
changes main .bowerrc file to the non-bundled version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git://github.com/phxdatasec/model-factory.git"
   },
-  "main": "./dist/model-factory-bundle.min.js",
+  "main": "./dist/model-factory.js",
   "ignore": [
     "**/.*",
     "node_modules",
@@ -19,10 +19,12 @@
     "src",
     "examples"
   ],
-  "devDependencies": {
+  "dependencies": {
     "uri-templates": "~0.1.5",
     "deep-diff": "~0.2.0",
-    "angular": "1.3.x",
+    "angular": "1.3.x"
+  },
+  "devDependencies": {
     "angular-mocks": "1.x",
     "angular-scenario": "1.x"
   }


### PR DESCRIPTION
moves angular and other deps from the "devDependencies" -> "dependencies" section. This
has the consequence that the other deps (uri-templates, deep-diff) will be automatically fetched by bower when
installed by others.
This should solve issue #5.

The [Getting Started](https://github.com/phxdatasec/model-factory/wiki/Getting-Started) section of the wiki has to be updated. I'll do so once the PR is validated and merged.
