### PR TITLE
fixes broken test due to syntax changes

### DIFF
--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -272,14 +272,14 @@ describe('A person model defined using modelFactory', function() {
 
         describe('when calling $revert', function() {
 
-            xit('should revert to the previous values of the object', function() {
+            it('should revert to the previous values of the object', function() {
                 var newModel = new PersonModel({
                     name: 'Juri'
                 });
 
                 // act
                 newModel.name = 'Jack';
-                newModel.$revert();
+                newModel.$rollback();
 
                 expect(newModel.name).toEqual('Juri');
             });
@@ -303,7 +303,7 @@ describe('A person model defined using modelFactory', function() {
                 $httpBackend.flush();
 
                 // act
-                newModel.$revert();
+                newModel.$rollback();
 
                 // assert
                 expect(newModel.name).toEqual('Jack'); // there is nothing to revert 'cause the model is fresh from the server'


### PR DESCRIPTION
Fixes test which has been broken and deactivated due to syntax changes: `$revert` -> `$rollback`.

(we should try to keep these tests working as changes go ahead :wink:  )
