### PR TITLE
Bugfix: Newly added models didn't get removed properly when calling $destroy

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -295,7 +295,7 @@ module.provider('$modelFactory', function(){
                     var args = Array.prototype.slice.call(arguments);
 
                     for(var i=0; i<args.length; i++){
-                        args[i] = wrapAsNewModelInstance(args[i]);
+                        args[i] = wrapAsNewModelInstance(args[i], value);
                     }
 
                     __oldPush.apply(value, args);

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -374,6 +374,32 @@ describe('A person model defined using modelFactory', function() {
                 expect(modelList.length).toEqual(2);
             });
 
+            it('should also properly remove an object that has just been added to the list before', function(){
+
+                var modelList = new PersonModel.List([{
+                    id: 1,
+                    name: 'Juri'
+                }]);
+
+                var newModel = new PersonModel({
+                    id: 2,
+                    name: 'Tom'
+                });
+
+                // act: add a new model to the list
+                modelList.push(newModel);
+                expect(modelList.length).toBe(2);
+
+                // act: delete the added model again
+                newModel.$destroy();
+                $httpBackend.expectDELETE('/api/people/2').respond(200, '');
+                $httpBackend.flush();
+
+                // I'd expect that it is properly removed from it
+                expect(modelList.length).toBe(1);
+                expect(modelList[0].name).toEqual('Juri');
+            });
+
             it('should NOT remove the deleted object from a model list when the deletion fails', function() {
                 var modelList = new PersonModel.List([{
                     id: 1,


### PR DESCRIPTION
Hi,

there's currently an issue that newly added models to an existing collection don't get removed when calling `$destroy` while it works fine for existing models (as has been already [proven by this test](https://github.com/Swimlane/model-factory/blob/master/test/spec/modelUsage.spec.js#L355)).

I added a regression test to verify the bug and fixed it in the PR. 

@amcdnl Could you do our usual ritual of reviewing my fix, merging it in + publishing it on bower :wink: 

Thx a lot
