### PR TITLE
Fix extendDeep when overriding already existing properties with primitive values

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -47,6 +47,10 @@ var extendDeep = function (dst) {
                             }));
                         } else if (angular.isObject(dst[key])) {
                             extendDeep(dst[key], value);
+                        } else {
+                            // if value is a simple type like a string, boolean or number
+                            // then assign it
+                            dst[key] = value;
                         }
                     } else if (!angular.isFunction(dst[key])) {
                         dst[key] = value;

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -574,4 +574,61 @@ describe('A person model defined using modelFactory', function() {
 
     });
 
+    describe('using the isArray property', function(){
+        var AddressModel, $httpBackend;
+
+        beforeEach(function() {
+            angular.module('test-module', ['modelFactory'])
+                .factory('AddressModel', function($modelFactory) {
+                    return $modelFactory('/api/addresses', {
+                        actions: {
+                            'query': {
+                                isArray: false
+                            },
+
+                            'myCustomAction': {
+                                url: 'customAction',
+                                isArray: false
+                            }
+                        }
+                    });
+                });
+        });
+
+        beforeEach(angular.mock.module('test-module'));
+
+        beforeEach(inject(function(_AddressModel_, _$httpBackend_) {
+            AddressModel = _AddressModel_;
+            $httpBackend = _$httpBackend_;
+        }));
+
+        afterEach(function() {
+            $httpBackend.verifyNoOutstandingExpectation();
+            $httpBackend.verifyNoOutstandingRequest();
+        });
+
+        it('when setting it to false should accept non-array responses', function(){
+            AddressModel.query()
+                .then(function(result){
+                    expect(result.rows.length).toBe(1);
+                    expect(result.numRecords).toBe(1);
+                });
+
+            $httpBackend.expectGET('/api/addresses').respond(200, { rows: [{ id: 1, street: 'test'}], numRecords: 1 });
+            $httpBackend.flush();
+        });
+
+        it('when setting it to false on a custom action should accept non-array responses', function(){
+            AddressModel.myCustomAction()
+                .then(function(result){
+                    expect(result.rows.length).toBe(1);
+                    expect(result.numRecords).toBe(1);
+                });
+
+            $httpBackend.expectGET('/api/addresses/customAction').respond(200, { rows: [{ id: 1, street: 'test'}], numRecords: 1 });
+            $httpBackend.flush();
+        });
+
+    });
+
 });


### PR DESCRIPTION
I tried to override the already existing `query` property like

``` javascript
actions: {
    query: {
        isArray: false
    }
}
```

This however didn't work before as the `extendDeep` function ignored them. I added a test to reproduce the issue and fixed it accordingly.

@amcdnl Just wanted you to review this change as I've see in the commit history that you did some changes on the `extendDeep` function already.
