### PR TITLE
allow to have URLs with custom placeholders

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -722,7 +722,8 @@ module.provider('$modelFactory', function(){
                                 if(resolvedVariable){
                                     // only remove params on GET requests as the
                                     // passed object is intended to be used
-                                    // as URL params
+                                    // as URL params. For persistent HTTP calls
+                                    // the object has to be left as it is (for now)
                                     if(method === 'GET'){
                                       delete params[variableName];
                                     }

--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -583,6 +583,10 @@ module.provider('$modelFactory', function(){
                         uri += '/' + clone.url;
                     }
 
+
+                    // set the uri to the base
+                    uri = Model.$url(uri, data, clone.method);
+
                     // attach the pk referece by default if it is a 'core' type
                     if(action === 'get' || action === 'post' || action === 'update' || action === 'delete'){
                         uri += '/{' + options.pk + '}';
@@ -613,7 +617,7 @@ module.provider('$modelFactory', function(){
                     uri = clone.url;
                 }
 
-                clone.url = Model.$url(uri, data);
+                clone.url = Model.$url(uri, data, clone.method);
 
                 // don't include the payload for DELETE requests
                 if(action !== 'delete'){
@@ -708,9 +712,28 @@ module.provider('$modelFactory', function(){
              * Based on:
              * https://github.com/geraintluff/uri-templates
              */
-            Model.$url = function(u, params){
+            Model.$url = function(u, params, method){
                 var uri = new UriTemplate(u || url)
-                    .fillFromObject(params || {});
+                            .fill(function(variableName){
+                                var resolvedVariable = params[variableName];
+
+                                // if we have a match, substitute and remove it
+                                // from the original params object
+                                if(resolvedVariable){
+                                    // only remove params on GET requests as the
+                                    // passed object is intended to be used
+                                    // as URL params
+                                    if(method === 'GET'){
+                                      delete params[variableName];
+                                    }
+
+                                    return resolvedVariable;
+                                }else{
+                                    // ?? log an error??
+                                    return null;
+                                }
+                            });
+                            // .fillFromObject(params || {});
 
                 if(options.stripTrailingSlashes){
                     uri = uri.replace(/\/+$/, '') || '/';

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -666,39 +666,39 @@ describe('A person model defined using modelFactory', function() {
         var $httpBackend;
 
         beforeEach(function() {
-            angular.module('test-module', ['modelFactory'])
-                .factory('PersonModel', function($modelFactory) {
-                    return $modelFactory('/api/people', {
-                        actions: {
+          angular.module('test-module', ['modelFactory'])
+              .factory('PersonModel', function($modelFactory) {
+                  return $modelFactory('/api/people', {
+                      actions: {
 
-                            // static
-                            queryChildren: {
-                                url: 'children',
-                                isArray: true
-                            },
+                          // static
+                          queryChildren: {
+                              url: 'children',
+                              isArray: true
+                          },
 
-                            getById: {
-                                url: 'child/{id}/some/subpath'
-                            },
+                          getById: {
+                              url: 'child/{id}/some/subpath'
+                          },
 
-                            getByName: {
-                                url: 'child/{name}/some/subpath'
-                            },
+                          getByName: {
+                              url: 'child/{name}/some/subpath'
+                          },
 
-                            // instance function
-                            '$serverCopy': {
-                                method: 'POST',
-                                url: 'copy/{name}'
-                            },
+                          // instance function
+                          '$serverCopy': {
+                              method: 'POST',
+                              url: 'copy/{name}'
+                          },
 
-                            '$customUpdate': {
-                                method: 'PUT',
-                                url: 'update/{name}'
-                            }
+                          '$customUpdate': {
+                              method: 'PUT',
+                              url: 'update/{name}'
+                          }
 
-                        }
-                    });
-                });
+                      }
+                  });
+              });
         });
 
         beforeEach(angular.mock.module('test-module'));
@@ -761,10 +761,6 @@ describe('A person model defined using modelFactory', function() {
                                 isArray: true
                             },
 
-                            getComplexUri: {
-                                url: 'child/{id}/some/subpath'
-                            },
-
                             // instance function
                             '$serverCopy': {
                                 method: 'POST',
@@ -782,13 +778,6 @@ describe('A person model defined using modelFactory', function() {
             PersonModel = _PersonModel_;
             $httpBackend = _$httpBackend_;
         }));
-
-        it('should allow to have variables in the url', function(){
-            PersonModel.getComplexUri({ id: 123 });
-
-            $httpBackend.expectGET('/api/people/child/123/some/subpath').respond(200, []);
-            $httpBackend.flush();
-        });
 
         it('should correctly call the defined url', function() {
             PersonModel.queryChildren();

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -662,6 +662,90 @@ describe('A person model defined using modelFactory', function() {
 
     });
 
+    describe('backend URL resolution', function() {
+        var $httpBackend;
+
+        beforeEach(function() {
+            angular.module('test-module', ['modelFactory'])
+                .factory('PersonModel', function($modelFactory) {
+                    return $modelFactory('/api/people', {
+                        actions: {
+
+                            // static
+                            queryChildren: {
+                                url: 'children',
+                                isArray: true
+                            },
+
+                            getById: {
+                                url: 'child/{id}/some/subpath'
+                            },
+
+                            getByName: {
+                                url: 'child/{name}/some/subpath'
+                            },
+
+                            // instance function
+                            '$serverCopy': {
+                                method: 'POST',
+                                url: 'copy/{name}'
+                            },
+
+                            '$customUpdate': {
+                                method: 'PUT',
+                                url: 'update/{name}'
+                            }
+
+                        }
+                    });
+                });
+        });
+
+        beforeEach(angular.mock.module('test-module'));
+
+        beforeEach(inject(function(_PersonModel_, _$httpBackend_) {
+            PersonModel = _PersonModel_;
+            $httpBackend = _$httpBackend_;
+        }));
+
+        it('should work with GET and id variable', function(){
+            PersonModel.getById({ id: 123 });
+
+            $httpBackend.expectGET('/api/people/child/123/some/subpath').respond(200, []);
+            $httpBackend.flush();
+        });
+
+        it('should work with GET and name variable', function(){
+            PersonModel.getByName({ name: 'juri' });
+
+            $httpBackend.expectGET('/api/people/child/juri/some/subpath').respond(200, []);
+            $httpBackend.flush();
+        });
+
+        it('should work with POST and name variable', function(){
+            var person = new PersonModel({
+              name: 'juri'
+            });
+
+            person.$serverCopy();
+
+            $httpBackend.expectPOST('/api/people/copy/juri').respond(200, []);
+            $httpBackend.flush();
+        });
+
+        it('should work with PUT and name variable', function(){
+            var person = new PersonModel({
+              name: 'juri'
+            });
+
+            person.$customUpdate();
+
+            $httpBackend.expectPUT('/api/people/update/juri').respond(200, []);
+            $httpBackend.flush();
+        });
+
+    });
+
     describe('with custom actions', function() {
         var $httpBackend;
 
@@ -675,6 +759,10 @@ describe('A person model defined using modelFactory', function() {
                             queryChildren: {
                                 url: 'children',
                                 isArray: true
+                            },
+
+                            getComplexUri: {
+                                url: 'child/{id}/some/subpath'
                             },
 
                             // instance function
@@ -694,6 +782,13 @@ describe('A person model defined using modelFactory', function() {
             PersonModel = _PersonModel_;
             $httpBackend = _$httpBackend_;
         }));
+
+        it('should allow to have variables in the url', function(){
+            PersonModel.getComplexUri({ id: 123 });
+
+            $httpBackend.expectGET('/api/people/child/123/some/subpath').respond(200, []);
+            $httpBackend.flush();
+        });
 
         it('should correctly call the defined url', function() {
             PersonModel.queryChildren();


### PR DESCRIPTION
Ok, this PR adds the ability to have variables in custom endpoints, like

``` javascript
angular.module('test-module', ['modelFactory'])
    .factory('PersonModel', function($modelFactory) {
        return $modelFactory('/api/people', {
            actions: {

                getById: {
                    url: 'child/{id}/some/subpath'
                },

                getByName: {
                    url: 'child/{name}/some/subpath'
                },

                // instance function
                '$serverCopy': {
                    method: 'POST',
                    url: 'copy/{name}'
                },

                '$customUpdate': {
                    method: 'PUT',
                    url: 'update/{name}'
                }

            }
        });
    });
```

The strategy is to pass the data to the `Model.$url(...)` method where it is being resolved using the UriTemplate lib. Furthermore, for GET requests, the matched variables are being removed, s.t. they're not appended again due to the `{?param*}` placeholder that is being attached by default.

@amcdnl Refactoring/improvement tips?? I don't quite like to pass the HTTP method into the `Model.$url(..)` function, but I have to...

(Also see #32 ) 
