### PR TITLE
fix(umd): now factory returns module

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -786,6 +786,8 @@ module.provider('$modelFactory', function(){
 
         return modelFactory;
     }];
+
+    return module;
 });
 
 });


### PR DESCRIPTION
As developer I would like to use `model-factory` like module:

``` javascript
import angular from 'angular';
import modelFactory from 'angular-model-factory';

export default angular.module('core', [
    modelFactory.name
]);
```

currently it returns `undefined`.
