### PR TITLE
fix(queryBuilding) fix duplicate slash in url

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -593,7 +593,9 @@ module.provider('$modelFactory', function(){
 
                     // if we have a url defined, append to base
                     if(clone.url) {
-                        uri += '/' + clone.url;
+                        //check if we need to add slash, or we only duplicate it
+                        var requiredSlash = !/^(\/|{\/)/.test(clone.url);
+                        uri += requiredSlash ? '/' + clone.url : clone.url;
                     }
 
 
@@ -602,7 +604,7 @@ module.provider('$modelFactory', function(){
 
                     // attach the pk referece by default if it is a 'core' type
                     if(action === 'get' || action === 'post' || action === 'update' || action === 'delete'){
-                        uri += '/{' + options.pk + '}';
+                        uri += '{/' + options.pk + '}';
                     }
 
                     if(clone.method === 'GET' && (angular.isString(data) || angular.isNumber(data))){

--- a/test/spec/modelUsage.spec.js
+++ b/test/spec/modelUsage.spec.js
@@ -1270,6 +1270,70 @@ describe('A person model defined using modelFactory', function() {
         });
     });
 
+
+    describe('when action url (or action template url) contains slash', function () {
+        var DummyGetModel, $httpBackend;
+        beforeEach(function () {
+            angular.module('test-module', ['modelFactory'])
+                .factory('DummyGetModel', function ($modelFactory) {
+                    return $modelFactory('/test/get/actionSlashTest', {
+                        actions: {
+                            get: {
+                                url: '{/templateParam,templateParam2}'
+                            },
+                            query: {
+                                url: '/simpleUrl'
+                            }
+                        }
+                    });
+                });
+        });
+
+        beforeEach(angular.mock.module('test-module'));
+
+        beforeEach(inject(function (_DummyGetModel_, _$httpBackend_) {
+            DummyGetModel = _DummyGetModel_;
+            $httpBackend = _$httpBackend_;
+        }));
+
+        it('should build query with template params and no duplicate slashes', function () {
+            DummyGetModel.get({
+                templateParam: '123',
+                templateParam2: '456'
+            });
+
+            $httpBackend.expectGET('/test/get/actionSlashTest/123/456').respond(200);
+            $httpBackend.flush();
+        });
+
+        it('should set pk as query param, if we have path params as template', function () {
+            DummyGetModel.get({
+                templateParam: '123',
+                templateParam2: '456',
+                id: 0
+            });
+
+            $httpBackend.expectGET('/test/get/actionSlashTest/123/456?id=0').respond(200);
+            $httpBackend.flush();
+        });
+
+        it('should query data without duplicate slash', function () {
+            DummyGetModel.query();
+
+            $httpBackend.expectGET('/test/get/actionSlashTest/simpleUrl').respond(200);
+            $httpBackend.flush();
+        });
+
+        it('should query data without duplicate slash and add query params', function () {
+            DummyGetModel.query({
+                query: 'param'
+            });
+
+            $httpBackend.expectGET('/test/get/actionSlashTest/simpleUrl?query=param').respond(200);
+            $httpBackend.flush();
+        });
+    });
+
     describe('regression test',function(){
         var Contact, Phone, Address;
 


### PR DESCRIPTION
The problem is that in some cases url is constructed with duplicated slash.
In our case that appears, when action url was is using template syntax `{/param,param2}`.

Basically browsers handle this correctly and fix this themselves, but in some environments we have test failing, so I think it's right to initially build correct url and not rely on external tools.
