### PR TITLE
fix($call) add params to signature to track parallel calls with different params

### DIFF
--- a/src/modelFactory.js
+++ b/src/modelFactory.js
@@ -650,7 +650,7 @@ module.provider('$modelFactory', function(){
              */
             Model.$call = function(params){
                 // if we have the promise in queue, return it
-                var signature = params.method + ':' + params.url;
+                var signature = params.method + ':' + params.url + ':' + angular.toJson(params.params);
                 if (promiseTracker[signature]) {
                     return promiseTracker[signature];
                 }


### PR DESCRIPTION
Parallel calls with the same method and url but with different parameters should be tracked.
